### PR TITLE
Fix `ContainerConfig` deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #
 - Add missing `ContainerSpec` fields, use correct `TaskSpec` in `ServiceSpec`
 - Fix `ContainerConfig::exposed_ports` serialization
+- Fix `ContainerConfig` desserialization (`cmd` field might be ommited from the response)
 
 # 0.4.0
 - Fix list endpoints

--- a/src/api/container/data.rs
+++ b/src/api/container/data.rs
@@ -118,7 +118,7 @@ pub struct ContainerConfig {
     pub open_stdin: bool,
     pub stdin_once: bool,
     pub env: Vec<String>,
-    pub cmd: Vec<String>,
+    pub cmd: Option<Vec<String>>,
     pub healthcheck: Option<HealthConfig>,
     pub args_escaped: Option<bool>,
     pub image: String,


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
2. This repository tries to stick with the community style conventions using [rustfmt](https://github.com/rust-lang-nursery/rustfmt#quick-start) with the *default* settings. If you have custom settings you may find that rustfmt
clutter the diff of your change with unrelated changes. Please apply formatting with `cargo +nightly fmt --all` before submitting a pr.
-->

## What did you implement:
This PR fixes deserialization of `ContainerConfig` making the `cmd` field optional. From what it seems the fields whose type is `strslice.StrSlice` can be omitted from the response.  I also verified other fields on the structure and they seem fine: https://github.com/moby/moby/blob/b316cc059a81d9abe7d7edb4e3620b5aa01ef5e4/api/types/container/config.go#L55 


Closes: #3 